### PR TITLE
Catch ins files

### DIFF
--- a/src/Language/Fortran/Extras.hs
+++ b/src/Language/Fortran/Extras.hs
@@ -226,7 +226,7 @@ withToolOptionsAndProgramOrBlock
 withToolOptionsAndProgramOrBlock programDescription programHeader optsParser handler = do
   RunOptions srcOptions toolOptions <-
     getRunOptions programDescription programHeader optsParser
-  ast <- if takeExtension (path srcOptions) == ".inc"
+  ast <- if takeExtension (path srcOptions) `elem` [".inc", ".ins"]
     then Left . (path srcOptions, ) <$> incFile srcOptions
     else Right <$> programFile srcOptions
   handler toolOptions ast


### PR DESCRIPTION
I'm not sure how common this is in the wider world, but we have a bunch of include files that use this extension (generally mechanically generated in some way but sometimes decades ago with an tool lost to time).

Given there are no restrictions on the file extensions that Fortran can include some other approach might make sense, perhaps try and parse anything that doesn't have a `.f`, `.f90` etc. extension, and then it can be left up to the tool caller to only run it on appropriate files.